### PR TITLE
Inline chunks don't exist in html-webpack-plugin and fix  log

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,19 +19,27 @@ InlineChunkPlugin.prototype.apply = function (compiler) {
 
             var publicPath = compilation.options.output.publicPath || '';
             if (publicPath && publicPath.substr(-1) !== '/') {
-                  publicPath += '/';
+                publicPath += '/';
             }
             _.each(me.options.inlineChunks, function (name) {
                 var chunkPath = (compilation.chunks.filter(function (chunk) {
                     return chunk.name === name;
                 })[0] || { files: [] }).files[0];
 
-                me.log("html-webpack-inline-chunk-plugin: Inlined " + chunkPath);
                 if (chunkPath) {
+                    me.log("html-webpack-inline-chunk-plugin: Inlined " + chunkPath);
+
                     var tag = _.find(htmlPluginData.body, { attributes: { src: publicPath + chunkPath } });
+                    var source = sourceMappingURL.removeFrom(compilation.assets[chunkPath].source());
                     if (tag) {
                         delete tag.attributes.src;
-                        tag.innerHTML = sourceMappingURL.removeFrom(compilation.assets[chunkPath].source());
+                        tag.innerHTML = source;
+                    } else {
+                        htmlPluginData.body.unshift({
+                            tagName: 'script',
+                            closeTag: true,
+                            innerHTML: source
+                        });
                     }
                 }
             });


### PR DESCRIPTION
if `chunkPath` is falsy, it may be defined in webpack entry, we can create a new script tag for it.